### PR TITLE
Remove Enabling WinRM from Windows Updates module

### DIFF
--- a/modules/WindowsBox.WinRM/WindowsBox.WinRM.psd1
+++ b/modules/WindowsBox.WinRM/WindowsBox.WinRM.psd1
@@ -12,7 +12,7 @@
 RootModule = 'WindowsBox.WinRM'
 
 # Version number of this module.
-ModuleVersion = '0.1'
+ModuleVersion = '0.2'
 
 # ID used to uniquely identify this module
 GUID = '1443e65d-b18e-4277-abc8-3eb60a8f1f52'
@@ -66,7 +66,7 @@ Description = 'Commands to enable WinRM on a Windows box'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Enable-WinRM')
+FunctionsToExport = @('Enable-WinRM', 'Enable-InsecureWinRM')
 
 # Cmdlets to export from this module
 CmdletsToExport = @()

--- a/modules/WindowsBox.WinRM/WindowsBox.WinRM.psm1
+++ b/modules/WindowsBox.WinRM/WindowsBox.WinRM.psm1
@@ -1,26 +1,71 @@
 <#
 .Synopsis
-    Enables WinRM
+    Enables WinRM insecurely over http (use only for localhost connections)
 .Description
-    This cmdlet enables the WinRM endpoint using http and basic auth by default
+    This cmdlet enables the WinRM endpoint using http and basic auth. This should
+    only be used via localhost since username and password are sent unencrypted
+    over the network.
+#>
+function Enable-InsecureWinRM {
+    # Ensure the Windows firewall allows WinRM https traffic over port 5985
+    Enable-NetFirewallRule -DisplayName 'Windows Remote Management (HTTP-In)'
+
+    Enable-WinRMWithLargeDefaults
+
+    # Enable insecure basic auth over http
+    winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+    winrm set winrm/config/service/auth '@{Basic="true"}'
+}
+
+<#
+.Synopsis
+    Enables WinRM over https
+.Description
+    This cmdlet enables the WinRM endpoint using https and basic auth. This creates
+    a self signed cert so you'll need to ensure your client ignores cert validation
+    errors.
 #>
 function Enable-WinRM {
+    # Ensure the Windows firewall allows WinRM https traffic over port 5986
+    New-NetFirewallRule -Name "WINRM-HTTPS-In-TCP" `
+        -DisplayName "Windows Remote Management (HTTPS-In)" `
+        -Description "Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]" `
+        -Group "Windows Remote Management" `
+        -Program "System" `
+        -Protocol TCP `
+        -LocalPort "5986" `
+        -Action Allow `
+        -Profile Domain,Private
+
+    New-NetFirewallRule -Name "WINRM-HTTPS-In-TCP-PUBLIC" `
+        -DisplayName "Windows Remote Management (HTTPS-In)" `
+        -Description "Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]" `
+        -Group "Windows Remote Management" `
+        -Program "System" `
+        -Protocol TCP `
+        -LocalPort "5986" `
+        -Action Allow `
+        -Profile Public
+
+    Enable-WinRMWithLargeDefaults
+
+    # Create self signed cert for TLS connections to WinRM
+    $cert = New-SelfSignedCertificate -CertstoreLocation Cert:\LocalMachine\My -DnsName "winrm"
+    New-Item -Path WSMan:\LocalHost\Listener -Transport HTTPS -Address * -CertificateThumbPrint $cert.Thumbprint -Force
+
+    # Enable basic auth over https
+    winrm set winrm/config/service '@{AllowUnencrypted="false"}'
+    winrm set winrm/config/service/auth '@{Basic="true"}'
+    winrm set 'winrm/config/listener?Address=*+Transport=HTTPS' "@{Port=`"5986`";Hostname=`"winrm`";CertificateThumbprint=`"$($cert.Thumbprint)`"}"
+}
+
+function Enable-WinRMWithLargeDefaults {
     # Enable WinRM with defaults
-    winrm quickconfig -q
+    Enable-PSRemoting -Force -SkipNetworkProfileCheck
 
     # Override defaults to allow unlimited shells/processes/memory
     winrm set winrm/config '@{MaxTimeoutms="7200000"}'
     winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="0"}'
     winrm set winrm/config/winrs '@{MaxProcessesPerShell="0"}'
     winrm set winrm/config/winrs '@{MaxShellsPerUser="0"}'
-
-    # Enable insecure basic auth over http
-    winrm set winrm/config/service '@{AllowUnencrypted="true"}'
-    winrm set winrm/config/service/auth '@{Basic="true"}'
-
-    # Ensure the Windows firewall allows WinRM traffic through
-    Enable-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)"
-
-    # Auto start the WinRM service
-    sc.exe config winrm start= auto
 }

--- a/modules/WindowsBox.WinRM/WindowsBox.WinRM.psm1
+++ b/modules/WindowsBox.WinRM/WindowsBox.WinRM.psm1
@@ -10,7 +10,7 @@ function Enable-InsecureWinRM {
     # Ensure the Windows firewall allows WinRM https traffic over port 5985
     Enable-NetFirewallRule -DisplayName 'Windows Remote Management (HTTP-In)'
 
-    Enable-WinRMWithLargeDefaults
+    Enable-WinRMConfiguration
 
     # Enable insecure basic auth over http
     winrm set winrm/config/service '@{AllowUnencrypted="true"}'
@@ -47,7 +47,7 @@ function Enable-WinRM {
         -Action Allow `
         -Profile Public
 
-    Enable-WinRMWithLargeDefaults
+    Enable-WinRMConfiguration
 
     # Create self signed cert for TLS connections to WinRM
     $cert = New-SelfSignedCertificate -CertstoreLocation Cert:\LocalMachine\My -DnsName "winrm"
@@ -59,7 +59,7 @@ function Enable-WinRM {
     winrm set 'winrm/config/listener?Address=*+Transport=HTTPS' "@{Port=`"5986`";Hostname=`"winrm`";CertificateThumbprint=`"$($cert.Thumbprint)`"}"
 }
 
-function Enable-WinRMWithLargeDefaults {
+function Enable-WinRMConfiguration {
     # Enable WinRM with defaults
     Enable-PSRemoting -Force -SkipNetworkProfileCheck
 

--- a/modules/WindowsBox.WindowsUpdates/WindowsBox.WindowsUpdates.psd1
+++ b/modules/WindowsBox.WindowsUpdates/WindowsBox.WindowsUpdates.psd1
@@ -12,7 +12,7 @@
 RootModule = 'WindowsBox.WindowsUpdates'
 
 # Version number of this module.
-ModuleVersion = '0.2'
+ModuleVersion = '0.3'
 
 # ID used to uniquely identify this module
 GUID = 'e46b71e1-e11d-4780-94c7-a65d64250ae8'
@@ -48,7 +48,7 @@ Description = 'Commands to install Windows Updates on a Windows box'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName='WindowsBox.WinRM'; ModuleVersion='0.1'; GUID='1443e65d-b18e-4277-abc8-3eb60a8f1f52'; })
+# RequiredModules = @()
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/modules/WindowsBox.WindowsUpdates/WindowsBox.WindowsUpdates.psm1
+++ b/modules/WindowsBox.WindowsUpdates/WindowsBox.WindowsUpdates.psm1
@@ -56,10 +56,8 @@ function Invoke-RebootOrComplete() {
                 Install-UpdateBatch
             } elseif ($script:Cycles -gt $script:MaxCycles) {
                 LogWrite "Exceeded Cycle Count - Stopping"
-                Enable-WinRM
             } else {
                 LogWrite "Done Installing Windows Updates"
-                Enable-WinRM
             }
         }
         1 {
@@ -151,7 +149,6 @@ function Install-UpdateBatch() {
         LogWrite 'No updates available to install...'
         $script:MoreUpdates=0
         $script:RestartRequired=0
-        Enable-WinRM
         break
     }
 

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,29 +1,39 @@
 # PS Gallery publish script to be called from AppVeyor
 #
 
-# ensure we have a PSGallery API key
-if ($null -eq $env:APIKEY) {
-  Write-Error '$env:APIKEY must be set before running'
-  exit 1
-}
-$apikey = $env:APIKEY
-
 $deploy=$false
-if (($env:appveyor_repo_branch -eq 'master') -and ($env:appveyor_repo_commit_message -like '*deploy*')) {
-  Write-Output "Skipping publish because not on master branch or commit message doesn't contain deploy"
+$apikey=''
+
+# Setup build environment, needed for BH* env vars
+Remove-Item env:BH*
+Set-BuildEnvironment
+
+if (($env:BHBranchName -eq 'master') -and ($env:BHCommitMessage -like '*deploy*')) {
+  Write-Output "Publishing! On master branch and found keyword 'deploy' in commit message"
+
+  # Ensure we have a PSGallery API key
+  if ($null -eq $env:APIKEY) {
+    Write-Error '$env:APIKEY must be set before publishing'
+    exit 1
+  }
+  $apikey = $env:APIKEY
   $deploy=$true
+} else {
+  Write-Output "Skipping publish because not on master branch or commit message doesn't contain the word deploy"
 }
 
 # loop over each module
 $modules = Get-ChildItem modules
 foreach ($m in $modules) {
+  # Reset build environment to the current module
+  Remove-Item env:BH*
   Set-BuildEnvironment -Path ".\modules\$($m.Name)"
 
-  # Grab the latest published version and bump the metadata
-  $version = Get-NextPSGalleryVersion -Name $env:BHProjectName
+  # Grab the latest published version number from nuget and bump it
+  $version = Get-NextNugetPackageVersion -Name $env:BHProjectName
   Update-Metadata -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -Value $version
 
-  # publish the new version if this is a master branch build
+  # Publish the new version if this is a master branch build
   if ($deploy) {
     Write-Output "Publishing $($m.Name) version $version"
     Publish-Module -Path ".\modules\$($m.Name)" -NuGetApiKey $apikey -Verbose


### PR DESCRIPTION
Removes the WinRM dependency from Windows Updates module and adds enabling WinRM semi-securely over https as the default of `Enable-WinRM`. To enable WinRM insecurely over plain http you must now use `Enable-InsecureWinRM`.

Updated the PS BuildHelpers usage for publishing. Let's deploy it!